### PR TITLE
Drop to snap daemon and use config file

### DIFF
--- a/influxdb/snap/hooks/install
+++ b/influxdb/snap/hooks/install
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+if [ -z "$SNAP_COMMON" ]; then
+    echo "SNAP_COMMON not set. Aborting install hook"
+    exit 1
+fi
+
+if [ ! -d "$SNAP_COMMON" ]; then
+    echo "SNAP_COMMON does not exist. Aborting install hook"
+    exit 1
+fi
+
+# create the db directory so both snap_daemon and root can acces it. See
+# https://forum.snapcraft.io/t/system-usernames/13386
+DBDIR="$SNAP_COMMON/db"
+if [ ! -d "$DBDIR" ]; then
+    mkdir "$DBDIR"
+    chmod 770 "$DBDIR"
+    chown snap_daemon "$DBDIR"  # keep group as 'root'
+fi

--- a/influxdb/snap/hooks/install
+++ b/influxdb/snap/hooks/install
@@ -19,3 +19,15 @@ if [ ! -d "$DBDIR" ]; then
     chmod 770 "$DBDIR"
     chown snap_daemon "$DBDIR"  # keep group as 'root'
 fi
+
+# Generate minimal config file
+CONFIG_DIR="$SNAP_COMMON/conf"
+CONFIG="$CONFIG_DIR/config.yaml"
+if [ ! -e "$CONFIG_DIR" ]; then
+    mkdir "$CONFIG_DIR"
+    cat > "$CONFIG" <<EOM
+bolt-path: $SNAP_COMMON/db/influxd.bolt
+engine-path: $SNAP_COMMON/db/engine
+EOM
+    chmod 644 "$CONFIG"
+fi

--- a/influxdb/snap/hooks/post-refresh
+++ b/influxdb/snap/hooks/post-refresh
@@ -31,3 +31,15 @@ if [ ! -f "$DBDIR/influxd.bolt" ]; then
     mv "$SNAP_COMMON/influxd.bolt" "$DBDIR/influxd.bolt"
     chown snap_daemon:snap_daemon "$DBDIR/influxd.bolt"
 fi
+
+# Migrate from command line args to config file
+CONFIG_DIR="$SNAP_COMMON/conf"
+CONFIG="$CONFIG_DIR/config.yaml"
+if [ ! -e "$CONFIG_DIR" ]; then
+    mkdir "$CONFIG_DIR"
+    cat > "$CONFIG" <<EOM
+bolt-path: $SNAP_COMMON/db/influxd.bolt
+engine-path: $SNAP_COMMON/db/engine
+EOM
+    chmod 644 "$CONFIG"
+fi

--- a/influxdb/snap/hooks/post-refresh
+++ b/influxdb/snap/hooks/post-refresh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+if [ -z "$SNAP_COMMON" ]; then
+    echo "SNAP_COMMON not set. Aborting install hook"
+    exit 1
+fi
+
+if [ ! -d "$SNAP_COMMON" ]; then
+    echo "SNAP_COMMON does not exist. Aborting install hook"
+    exit 1
+fi
+
+# Migrate from root run to snap_daemon
+
+# create the db directory so both snap_daemon and root can acces it. See
+# https://forum.snapcraft.io/t/system-usernames/13386
+DBDIR="$SNAP_COMMON/db"
+if [ ! -d "$DBDIR" ]; then
+    mkdir "$DBDIR"
+    chmod 770 "$DBDIR"
+    chown snap_daemon "$DBDIR"  # keep group as 'root'
+fi
+
+if [ ! -d "$DBDIR/engine" ]; then
+    mv "$SNAP_COMMON/engine" "$DBDIR/engine"
+    chown -R snap_daemon:snap_daemon "$DBDIR/engine"
+fi
+
+if [ ! -f "$DBDIR/influxd.bolt" ]; then
+    mv "$SNAP_COMMON/influxd.bolt" "$DBDIR/influxd.bolt"
+    chown snap_daemon:snap_daemon "$DBDIR/influxd.bolt"
+fi

--- a/influxdb/snapcraft.yaml
+++ b/influxdb/snapcraft.yaml
@@ -39,7 +39,9 @@ system-usernames:
 
 apps:
   influxd:
-    command: usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- $SNAP/influxd --bolt-path $SNAP_COMMON/db/influxd.bolt --engine-path $SNAP_COMMON/db/engine
+    command: usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- $SNAP/influxd
+    environment:
+      INFLUXD_CONFIG_PATH: $SNAP_COMMON/conf
     daemon: simple
     plugs:
       - network

--- a/influxdb/snapcraft.yaml
+++ b/influxdb/snapcraft.yaml
@@ -16,7 +16,7 @@ architectures:
 parts:
   influxdb:
     plugin: dump
-    source: 
+    source:
       - on arm64: https://dl.influxdata.com/platform/nightlies/influx_nightly_linux_arm64.tar.gz
       - else: https://dl.influxdata.com/platform/nightlies/influx_nightly_linux_amd64.tar.gz
     override-build: |
@@ -25,12 +25,28 @@ parts:
       snapcraftctl set-version $VERSION
     stage:
       - influxd
+  staged:
+    plugin: nil
+    stage-packages:
+      - setpriv
+    stage:
+      - -lib        # libcap-ng.so.0.0.0 is in base
+      - -usr/lib    # don't ship empty dir
+      - -usr/share
+
+system-usernames:
+  snap_daemon: shared
 
 apps:
   influxd:
-    command: influxd --bolt-path $SNAP_COMMON/influxd.bolt --engine-path $SNAP_COMMON/engine
+    command: usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- $SNAP/influxd --bolt-path $SNAP_COMMON/db/influxd.bolt --engine-path $SNAP_COMMON/db/engine
     daemon: simple
     plugs:
       - network
       - network-bind
 
+hooks:
+  install:
+    plugs: []
+  post-refresh:
+    plugs: []


### PR DESCRIPTION
* run influxdb as non-root
    
    When running influxdb as the snap_daemon user, we must create a
    directory that snap_daemon can write to in $SNAP_COMMON. Use
    $SNAP_COMMON/db for the new directory and create it in the install hook.
    
    Stage the 'setpriv' command (but leave out extraneous empty and unneeded
    directories) to drop to snap_daemon.
    
    Create a post-refresh hook to move from $SNAP_COMMON to $SNAP_COMMON/db.

    While there is an opportunity for code refactoring in install and post-refresh,
    it wasn't clear if we wanted to support migration (and so omit the post-refresh)
    and instead call this a breaking change.

* move to using INFLUXD_CONFIG_PATH and a config file instead of args
    
    snapcraft.yaml previously hard-coded --bolt-path and --engine-path,
    which is fine except we'd like to allow administrators to set other
    options (eg, reporting-disabled). Set INFLUXD_CONFIG_PATH and create
    $INFLUXD_CONFIG_PATH/config.yaml to set bolt-path and engine-path. This
    also sets the stage for adjusting the snap to use 'snap set' for
    configuring the http-bind-address, log-level, tls-cert, tls-key, etc
    since the snap can manage $INFLUXD_CONFIG_PATH/config.yaml via its
    configure hook.

    Note, while the post-refresh hook runs after daemons are stopped and 
    before daemons are started, after refresh there are log errors related
    to migration even though all the permissions are correct:

    influxdb.influxd[190315]: ts=2021-03-04T15:01:06.857268Z lvl=error
    msg="Failed to apply migrations" log_id=0SgRxQbW000 error="up: reading
    migrations: migration \"add index \\\"dbrpbyorgv1\\\"\": migration
    specification not found"

    At this time, it is not known if this is a difference in nightlies or
    related to the change of ownership (eg, influxdb encoding the uid for 
    some reason). This is likely the former.